### PR TITLE
Fix: try out pm2 for the current configuration

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  apps: [
+    {
+      name: "Lynx Web Shop App",
+      script: "./node_modules/next/dist/bin/next",
+      args: "start -p " + (process.env.PORT || 3000),
+      watch: false,
+      autorestart: true,
+    },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "pm2 start ecosystem.config.js --no-daemon",
+    "start:local": "next start",
     "lint": "next lint"
   },
   "dependencies": {


### PR DESCRIPTION
- Added ecosystem.config.js which points to next.js server implementation
- changed npm start -> npm start local because azure uses npm run start
- npm start command = pm2 command